### PR TITLE
Fix AgeAndGender section labels - Israel Gov data

### DIFF
--- a/scrapers/covid-19/govScrapers/getIsrael.js
+++ b/scrapers/covid-19/govScrapers/getIsrael.js
@@ -47,9 +47,9 @@ const parseData = (data) => {
 	return {
 		updated: new Date(data[0].data.lastUpdate).valueOf(),
 		data: {
-			sickByAge: data[5].data.map((entry) => {
+			sickByAge: data[5].data.map((entry, i) => {
 				const { section, male, female } = entry;
-				return { section: `ages ${section} - ${section + 10}`, male, female };
+				return { section: i === data[5].data.length - 1 ? `+${section}` : `${section} - ${section + 9}`, male, female };
 			}),
 			healthPersonnel: {
 				verifiedDoctors: staffData.Verified_Doctors,


### PR DESCRIPTION
Removed “ages” from label, better for i18n.
Corrected segment increments from “0 - 10” to “0 - 9” and so on...
And replaced “ages 90 – 100” with “+90” to match the governments source.
Screenshot from governments website:
![Annotation 2020-08-01 192150](https://user-images.githubusercontent.com/12494197/89112433-7d10e780-d430-11ea-827a-c7f1c986e45a.png)