### PR TITLE
Get canada/csv

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "express": "^4.16.3",
     "ioredis": "*",
     "mailgun-js": "^0.22.0",
-    "moment": "^2.27.0",
     "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express": "^4.16.3",
     "ioredis": "*",
     "mailgun-js": "^0.22.0",
+    "moment": "^2.27.0",
     "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {

--- a/scrapers/covid-19/govScrapers/getCanada.js
+++ b/scrapers/covid-19/govScrapers/getCanada.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 const logger = require('../../../utils/logger');
 const csvUtils = require('../../../utils/csvUtils');
-const moment = require('moment');
 
 /**
  * Return array of provinces that match today's date (initial csv is historical)
@@ -9,8 +8,9 @@ const moment = require('moment');
  * @returns {Array}				Data for canadian province
  */
 const filterByDate = (csv) => {
-	const date = moment().format('DD-MM-YYYY');
-	return csv.filter(row => row.date === date);
+	const date = new Date();
+	date.setDate(date.getDate() - 1);
+	return csv.filter(row => row.date === `${date.getDate().toString().padStart(2, '0')}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getFullYear()}`);
 };
 
 /**

--- a/scrapers/covid-19/govScrapers/getCanada.js
+++ b/scrapers/covid-19/govScrapers/getCanada.js
@@ -1,39 +1,31 @@
 const axios = require('axios');
-const cheerio = require('cheerio');
 const logger = require('../../../utils/logger');
-
-const columns = ['province', 'cases', 'deaths'];
+const csvUtils = require('../../../utils/csvUtils');
+const moment = require('moment');
 
 /**
- * Return object reflecting a row of data from Canadian government site
- * @param 	{number} 	_ 		Index getting passed when using .map()
- * @param 	{Object} 	row		The row to extract data from
- * @returns {Object}				Data for canadian province with entries for each column in @constant columns
+ * Return array of provinces that match today's date (initial csv is historical)
+ * @param 	{Object} 	csv		The row to extract data from
+ * @returns {Array}				Data for canadian province
  */
-const mapRows = (_, row) => {
-	const province = { updated: Date.now() };
-	cheerio(row).children('td').each((index, cell) => {
-		cell = cheerio.load(cell);
-		switch (index) {
-			case 0: {
-				province[columns[index]] = cell.text() === 'Canada' ? 'Total' : cell.text();
-				break;
-			}
-			default: {
-				province[columns[index]] = parseInt(cell.text().replace(/,/g, '')) || null;
-			}
-		}
-	});
-	return province;
+const filterByDate = (csv) => {
+	const date = moment().format('DD-MM-YYYY');
+	return csv.filter(row => row.date === date);
 };
 
 /**
- * Scrapes Canadian government site and fills array of data from table
+ * Requests and parses csv data that is used to populate the data table on the Canadian government site
  */
 const canadaData = async () => {
 	try {
-		const html = cheerio.load((await axios.get('https://www.canada.ca/en/public-health/services/diseases/2019-novel-coronavirus-infection.html')).data);
-		return html(`table#dataTable`).children('tbody:first-of-type').children('tr').map(mapRows).get();
+		const canadaRes = (await axios.get('https://health-infobase.canada.ca/src/data/covidLive/covid19.csv')).data;
+		const parsedCanadaData = await csvUtils.parseCsvData(canadaRes);
+		return filterByDate(parsedCanadaData).map(province => ({
+			updated: Date.now(),
+			province: province.prname === 'Canada' ? 'Total' : province.prname,
+			cases: parseInt(province.numconf) || 0,
+			deaths: parseInt(province.numdeaths) || 0
+		}));
 	} catch (err) {
 		logger.err('Error: Requesting Canada Gov Data failed!', err);
 		return null;


### PR DESCRIPTION
COVID-19 table data on the [Canadian government website](https://www.canada.ca/en/public-health/services/diseases/2019-novel-coronavirus-infection.html) is no longer available. Instead, we'll grab the data from their [source csv file](https://health-infobase.canada.ca/src/data/covidLive/covid19.csv). As a result, `getCanada.js` had to be rewritten. 

The csv includes historical COVID-19 data, which may be useful in the future. But for now, I've filtered it down to the current date.

Note: I've added moment.js to the `package.json`. If the package size is an issue, I can find a way around it.