### PR TITLE
Israel gov tests data correction

### DIFF
--- a/scrapers/covid-19/govScrapers/getIsrael.js
+++ b/scrapers/covid-19/govScrapers/getIsrael.js
@@ -3,15 +3,15 @@ const logger = require('../../../utils/logger');
 
 const params = {
 	requests: [
-		{ queryName: 'lastUpdate', single: true },
-		{ queryName: 'patientsPerDate' },
-		{ queryName: 'deadPatientsPerDate' },
-		{ queryName: 'recoveredPerDay' },
-		{ queryName: 'testResultsPerDate' },
-		{ queryName: 'infectedByAgeAndGenderPublic', parameters: { ageSections: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90] } },
-		{ queryName: 'isolatedDoctorsAndNurses' },
-		{ queryName: 'contagionDataPerCityPublic' },
-		{ queryName: 'hospitalStatus' }
+		{ id: 1, queryName: 'lastUpdate', single: true },
+		{ id: 5, queryName: 'patientsPerDate' },
+		{ id: 6, queryName: 'deadPatientsPerDate' },
+		{ id: 7, queryName: 'recoveredPerDay' },
+		{ id: 8, queryName: 'testResultsPerDate' },
+		{ id: 11, queryName: 'infectedByAgeAndGenderPublic', parameters: { ageSections: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90] } },
+		{ id: 12, queryName: 'isolatedDoctorsAndNurses' },
+		{ id: 14, queryName: 'contagionDataPerCityPublic' },
+		{ id: 15, queryName: 'hospitalStatus' }
 	]
 };
 
@@ -37,7 +37,7 @@ const parseData = (data) => {
 		standardOccupancy: elem.StandardOccupancy,
 		newDeaths: deadPatientsPerDay[index].amount,
 		newlyRecovered: recoveredPerDay[index].amount,
-		newTestsTaken: testsPerDay[index].amount,
+		newTestsTaken: testsPerDay[index].amountVirusDiagnosis,
 		newPositiveTests: testsPerDay[index].positiveAmount,
 		activeNoncritical: elem.CountEasyStatus,
 		activeModerate: elem.CountMediumStatus,


### PR DESCRIPTION
 - Added back the source id's of request queries for easier maintenance. (Remove it if you want)
 - NewTestsTaken was showing total new tests including recovery diagnostic tests, fixed it to show new regular virus diagnosis tests taken without recovery tests, screenshot from the source website:
![Annotation 2020-08-11 013734](https://user-images.githubusercontent.com/12494197/89838315-996cfc80-db73-11ea-8048-43cd957870f7.jpg)

"הנתונים אינם כוללים מידע על בדיקות לאבחון החלמה" 
Translation: The data does not include information on tests for recovery diagnosis.

![image](https://user-images.githubusercontent.com/12494197/89838158-31b6b180-db73-11ea-8f99-2f07f050d319.png)

Basically:
`amount` = total new tests including recovery diagnosis. From what can be understood… it's not used on the gov's dashboard.
`amountVirusDiagnosis` = new virus diagnosis tests.
`positiveAmount` = new positive test result.



Thanks