### PR TITLE
Mexico fix

### DIFF
--- a/scrapers/covid-19/govScrapers/getMexico.js
+++ b/scrapers/covid-19/govScrapers/getMexico.js
@@ -40,8 +40,8 @@ const stateIDs = [
 
 // an object to initialize the FormData object that must be sent with the requests
 const formData = {
-	nationalCasesByGender: querystring.stringify({ cve: '000', nom: 'nacional', sPatType: 'Confirmados' }),
-	nationalDeathsByGender: querystring.stringify({ cve: '000', nom: 'nacional', sPatType: 'Defunciones' }),
+	nationalCasesToday: querystring.stringify({ cve: '000', nom: 'nacional', sPatType: 'Confirmados' }),
+	nationalDeathsToday: querystring.stringify({ cve: '000', nom: 'nacional', sPatType: 'Defunciones' }),
 	stateCases: querystring.stringify({ cve: '', nom: '', sPatType: 'Confirmados' }),
 	stateDeaths: querystring.stringify({ cve: '', nom: '', sPatType: 'Defunciones' }),
 	stateSuspects: querystring.stringify({ cve: '', nom: '', sPatType: 'Sospechosos' }),
@@ -88,7 +88,7 @@ const getInnerHTML = (res, identifier) => parseInt(res.substring(res.indexOf(ide
  * @param	{string} res	The response body string to extract data from
  * @returns {Object}	National data for Mexico
  */
-const getNationalByGender = (res) => filterByDate(JSON.parse(res.substring(res.lastIndexOf('['), res.lastIndexOf(']') + 1)))[0];
+const getNationalToday = (res) => filterByDate(JSON.parse(res.substring(res.lastIndexOf('['), res.lastIndexOf(']') + 1)))[0];
 
 /**
  * Creates and returns an object containing data for each tracked Mexican state
@@ -123,8 +123,8 @@ const mexicoData = async () => {
 	const SOURCE_URL = 'https://coronavirus.gob.mx/datos/Overview/info/getInfo.php';
 
 	try {
-		const nationalCasesByGender = getNationalByGender((await axios.post(SOURCE_URL, formData.nationalCasesByGender)).data);
-		const nationalDeathsByGender = getNationalByGender((await axios.post(SOURCE_URL, formData.nationalDeathsByGender)).data);
+		const nationalCasesToday = getNationalToday((await axios.post(SOURCE_URL, formData.nationalCasesToday)).data);
+		const nationalDeathsToday = getNationalToday((await axios.post(SOURCE_URL, formData.nationalDeathsToday)).data);
 		const stateCases = getState((await axios.post(SOURCE_URL, formData.stateCases)).data);
 		const stateDeaths = getState((await axios.post(SOURCE_URL, formData.stateDeaths)).data);
 		const stateSuspects = getState((await axios.post(SOURCE_URL, formData.stateSuspects)).data);
@@ -149,16 +149,16 @@ const mexicoData = async () => {
 			updated: Date.now(),
 			nationalData: {
 				todayCases: {
-					sourceUpdated: nationalCasesByGender.date,
-					male: nationalCasesByGender.Masculino,
-					female: nationalCasesByGender.Femenino,
-					total: nationalCasesByGender.total
+					sourceUpdated: nationalCasesToday.date,
+					male: nationalCasesToday.Masculino,
+					female: nationalCasesToday.Femenino,
+					total: nationalCasesToday.total
 				},
 				todayDeaths: {
-					sourceUpdated: nationalDeathsByGender.date,
-					male: nationalDeathsByGender.Masculino,
-					female: nationalDeathsByGender.Femenino,
-					total: nationalDeathsByGender.total
+					sourceUpdated: nationalDeathsToday.date,
+					male: nationalDeathsToday.Masculino,
+					female: nationalDeathsToday.Femenino,
+					total: nationalDeathsToday.total
 				},
 				casesAccumulated,
 				deathsAccumulated,

--- a/scrapers/covid-19/govScrapers/getMexico.js
+++ b/scrapers/covid-19/govScrapers/getMexico.js
@@ -106,9 +106,9 @@ const getState = (res) => {
 };
 
 /**
- * Gets national Active, Negative, Suspect, and Recovered counts
+ * Gets national Active, Negative, Suspect, and Recovered, Confirmed, Death counts
  * @param {string} res	The response body string to extract data from
- * @returns {Object}	{ active, negative, suspect, recovered }
+ * @returns {Object}	{ activeCases, negativeCases, suspectCases, recovered, casesAccumulated, deathsAccumulated }
  */
 const getNationalCaseData = (res) => ({
 	activeCases: getInnerHTML(res, 'gsActDIV'),

--- a/tests/v2/api_gov.spec.js
+++ b/tests/v2/api_gov.spec.js
@@ -472,13 +472,12 @@ describe('TESTING /v2/gov/UK', () => {
 });
 
 describe('TESTING /v2/gov/mexico', () => {
-	it('/v2/covid-19/gov/mexico correct properties', (done) => {
+	it('/v2/gov/mexico correct properties', (done) => {
 		chai.request(app)
 			.get('/v2/gov/mexico')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'object');
 				res.body.should.have.property('updated');
-				res.body.should.have.property('sourceUpdated');
 				res.body.should.have.property('nationalData');
 				res.body.should.have.property('stateData');
 				res.body.should.have.property('source');
@@ -490,9 +489,11 @@ describe('TESTING /v2/gov/mexico', () => {
 				res.body.nationalData.should.have.property('negativeCases');
 				res.body.nationalData.should.have.property('suspectCases');
 				res.body.nationalData.should.have.property('recovered');
+				res.body.nationalData.todayCases.should.have.property('sourceUpdated');
 				res.body.nationalData.todayCases.should.have.property('male');
 				res.body.nationalData.todayCases.should.have.property('female');
 				res.body.nationalData.todayCases.should.have.property('total');
+				res.body.nationalData.todayDeaths.should.have.property('sourceUpdated');
 				res.body.nationalData.todayDeaths.should.have.property('male');
 				res.body.nationalData.todayDeaths.should.have.property('female');
 				res.body.nationalData.todayDeaths.should.have.property('total');

--- a/tests/v3/covid-19/api_gov.spec.js
+++ b/tests/v3/covid-19/api_gov.spec.js
@@ -538,7 +538,6 @@ describe('TESTING /v3/covid-19/gov/mexico', () => {
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'object');
 				res.body.should.have.property('updated');
-				res.body.should.have.property('sourceUpdated');
 				res.body.should.have.property('nationalData');
 				res.body.should.have.property('stateData');
 				res.body.should.have.property('source');
@@ -550,9 +549,11 @@ describe('TESTING /v3/covid-19/gov/mexico', () => {
 				res.body.nationalData.should.have.property('negativeCases');
 				res.body.nationalData.should.have.property('suspectCases');
 				res.body.nationalData.should.have.property('recovered');
+				res.body.nationalData.todayCases.should.have.property('sourceUpdated');
 				res.body.nationalData.todayCases.should.have.property('male');
 				res.body.nationalData.todayCases.should.have.property('female');
 				res.body.nationalData.todayCases.should.have.property('total');
+				res.body.nationalData.todayDeaths.should.have.property('sourceUpdated');
 				res.body.nationalData.todayDeaths.should.have.property('male');
 				res.body.nationalData.todayDeaths.should.have.property('female');
 				res.body.nationalData.todayDeaths.should.have.property('total');


### PR DESCRIPTION
This should address the issues causing this scraper to fail previously. 

- adjusted `filterByDate` to allow for results up to 2-day old data (only for `nationalData.todayCases` and `nationalData.todayDeaths`). These 2 properties can also have different source dates. `sourceUpdated` property added to each to make this clear.
- get national accumulated case and death count from same source as active/suspect/negative/recovered to assure that these stay consistent
- rename a few functions and objects to remain clear
- adjust tests to follow this structure

Updated (and hopefully final) response structure:
```
{
  updated: 1597126121684,
  nationalData: {
    todayCases: { sourceUpdated: '2020-08-10', male: 1, female: 4, total: 5 },
    todayDeaths: { sourceUpdated: '2020-08-10', male: 1, female: 1, total: 2 },
    casesAccumulated: 485836,
    deathsAccumulated: 53003,
    activeCases: 28048,
    negativeCases: 532028,
    suspectCases: 79213,
    recovered: 327993
  },
  stateData: [
    {
      state: 'aguascalientes',
      confirmed: 4523,
      negative: 8962,
      suspect: 311,
      deaths: 283
    },
    ...
  ],
  source: 'https://coronavirus.gob.mx/datos/'
}

```