### PR TITLE
fix NYT endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const bodyParser = require('body-parser');
 const logger = require('./utils/logger');
 const path = require('path');
 const { config, port, redis, scraper, keys } = require('./routes/instances');
+const { updateNYTCache, updateAppleCache } = require('./utils/cache');
 
 if (config.sentry_key) Sentry.init({ dsn: config.sentry_key });
 
@@ -96,5 +97,8 @@ app.use(require('./routes/v3/covid-19/apiVaccine'));
 app.use(require('./routes/v3/influenza/apiInfluenza'));
 
 app.listen(port, () => logger.info(`Your app is listening on port ${port}`));
+
+updateNYTCache();
+updateAppleCache();
 
 module.exports = app;


### PR DESCRIPTION
Add back cache calls closes #840 