### PR TITLE
Issue/#844

### DIFF
--- a/public/apidocs/swagger_v3.json
+++ b/public/apidocs/swagger_v3.json
@@ -860,6 +860,15 @@
           "tags": [
             "COVID-19: NYT"
           ],
+          "parameters": [
+            {
+              "name": "lastdays",
+              "in": "query",
+              "default": 30,
+              "description": "Number of days to return. Use 'all' for the full data set (e.g. 15, all, 24)",
+              "type": "string"
+            }
+          ],
           "summary": "Get COVID-19 time series data for all states, with an entry for each day since the pandemic began",
           "responses": {
             "200": {
@@ -877,6 +886,13 @@
             "COVID-19: NYT"
           ],
           "parameters": [
+            {
+              "name": "lastdays",
+              "in": "query",
+              "default": 30,
+              "description": "Number of days to return. Use 'all' for the full data set (e.g. 15, all, 24)",
+              "type": "string"
+            },
             {
               "name": "state",
               "in": "path",
@@ -927,6 +943,13 @@
             "COVID-19: NYT"
           ],
           "parameters": [
+            {
+              "name": "lastdays",
+              "in": "query",
+              "default": 30,
+              "description": "Number of days to return. Use 'all' for the full data set (e.g. 15, all, 24)",
+              "type": "string"
+            },
             {
               "name": "county",
               "in": "path",

--- a/routes/v3/covid-19/apiNYT.js
+++ b/routes/v3/covid-19/apiNYT.js
@@ -2,11 +2,15 @@
 const router = require('express').Router();
 const { nytCounties, nytStates, nytNationwide } = require('../../../utils/cache');
 
-router.get('/v3/covid-19/nyt/states', async (req, res) => res.send(nytStates()));
+router.get('/v3/covid-19/nyt/states', async (req, res) => {
+	const { lastdays } = req.query;
+	res.send(nytStates(lastdays));
+});
 
 router.get('/v3/covid-19/nyt/states/:state', async (req, res) => {
 	const { state: queryState } = req.params;
-	const data = nytStates();
+	const { lastdays } = req.query;
+	const data = nytStates(lastdays);
 	if (queryState) {
 		const stateArr = queryState.trim().split(/,[\s+]?/).map((state) => state.toLowerCase());
 		const stateData = data.filter(({ state }) => stateArr.includes(state.toLowerCase()));
@@ -26,7 +30,9 @@ router.get('/v3/covid-19/nyt/counties', async (req, res) => {
 
 router.get('/v3/covid-19/nyt/counties/:county', async (req, res) => {
 	const { county: queryCounty } = req.params;
-	const data = nytCounties();
+	const { lastdays } = req.query;
+	// Fetching data filtered on the basis of lastdays
+	const data = nytCounties(lastdays);
 	if (queryCounty) {
 		const countyArr = queryCounty.trim().split(/,[\s+?]/).map((county) => county.toLowerCase());
 		const countyData = data.filter(({ county }) => countyArr.includes(county.toLowerCase()));

--- a/tests/v3/covid-19/api_nyt.spec.js
+++ b/tests/v3/covid-19/api_nyt.spec.js
@@ -18,20 +18,22 @@ describe('TESTING /v3/covid-19/nyt/states', () => {
 
 	it('/v3/covid-19/nyt/states lastdays check test case', (done) => {
 		chai.request(app)
-			.get('/v3/covid-19/nyt/states?lastdays=1')
+			.get('/v3/covid-19/nyt/states?lastdays=2')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				Object.keys(res.body).length.should.equal(55);
+				Object.keys(res.body).length.should.greaterThan(50);
+				Object.keys(res.body).length.should.lessThan(120);
 				done();
 			});
 	});
 
 	it('/v3/covid-19/nyt/states lastdays check test case and correct state', (done) => {
 		chai.request(app)
-			.get('/v3/covid-19/nyt/states/Washington?lastdays=1')
+			.get('/v3/covid-19/nyt/states/Washington?lastdays=2')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				Object.keys(res.body).length.should.equal(1);
+				Object.keys(res.body).length.should.greaterThan(0);
+				Object.keys(res.body).length.should.lessThan(3);
 				done();
 			});
 	});
@@ -102,9 +104,9 @@ describe('TESTING /v3/covid-19/nyt/counties', () => {
 			});
 	});
 
-	it('/v3/covid-19/nyt/counties lastdays = 1 param', (done) => {
+	it('/v3/covid-19/nyt/counties lastdays = 2 param', (done) => {
 		chai.request(app)
-			.get('/v3/covid-19/nyt/counties?lastdays=1')
+			.get('/v3/covid-19/nyt/counties?lastdays=2')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
 				Object.keys(res.body).length.should.greaterThan(3000);

--- a/tests/v3/covid-19/api_nyt.spec.js
+++ b/tests/v3/covid-19/api_nyt.spec.js
@@ -16,6 +16,26 @@ describe('TESTING /v3/covid-19/nyt/states', () => {
 			});
 	});
 
+	it('/v3/covid-19/nyt/states lastdays check test case', (done) => {
+		chai.request(app)
+			.get('/v3/covid-19/nyt/states?lastdays=1')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'array');
+				Object.keys(res.body).length.should.equal(55);
+				done();
+			});
+	});
+
+	it('/v3/covid-19/nyt/states lastdays check test case and correct state', (done) => {
+		chai.request(app)
+			.get('/v3/covid-19/nyt/states/Washington?lastdays=1')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'array');
+				Object.keys(res.body).length.should.equal(1);
+				done();
+			});
+	});
+
 	it('/v3/covid-19/nyt/states get correct state', (done) => {
 		chai.request(app)
 			.get('/v3/covid-19/nyt/states/California')
@@ -89,6 +109,16 @@ describe('TESTING /v3/covid-19/nyt/counties', () => {
 				testBasicProperties(err, res, 200, 'array');
 				Object.keys(res.body).length.should.greaterThan(3000);
 				Object.keys(res.body).length.should.lessThan(10000);
+				done();
+			});
+	});
+
+	it('/v3/covid-19/nyt/counties lastdays check test case and correct county', (done) => {
+		chai.request(app)
+			.get('/v3/covid-19/nyt/counties/Blount?lastdays=1')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'array');
+				Object.keys(res.body).length.should.equal(2);
 				done();
 			});
 	});

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -11,6 +11,13 @@ exports.currentStatus = {
 	appleData: undefined
 };
 
+const calculatePriorDate = (lastDays) => {
+	var priorDate = new Date();
+	priorDate.setDate(priorDate.getDate() - lastDays);
+	// priorDate = priorDate.toISOString().slice(0, 10);
+	return priorDate.toISOString().slice(0, 10);
+};
+
 // Series of get calls to retrieve current state of cache
 /**
  * Parses NYT Counties data
@@ -21,13 +28,21 @@ exports.nytCounties = (lastdays = 30) => {
 	if (lastdays === 'all') {
 		return this.currentStatus.nytCounties;
 	} else {
-		var priorDate = new Date();
-		priorDate.setDate(priorDate.getDate() - lastdays);
-		priorDate = priorDate.toISOString().slice(0, 10);
-		return this.currentStatus.nytCounties.filter((data) => data.date >= priorDate);
+		const prior = calculatePriorDate(lastdays);
+		return this.currentStatus.nytCounties.filter((data) => data.date >= prior);
 	}
 };
-exports.nytStates = () => this.currentStatus.nytStates;
+
+exports.nytStates = (lastdays = 30) => {
+	if (lastdays === 'all') {
+		return this.currentStatus.nytStates;
+	} else {
+		const prior = calculatePriorDate(lastdays);
+		return this.currentStatus.nytStates.filter((data) => data.date >= prior);
+	}
+};
+
+// exports.nytStates = () => this.currentStatus.nytStates;
 exports.nytNationwide = () => this.currentStatus.nytNationwide;
 exports.appleData = () => this.currentStatus.appleData;
 
@@ -47,6 +62,9 @@ exports.updateNYTCache = async () => {
 			this.currentStatus.nytCounties = parsedCountyData.map(numericalStats);
 			this.currentStatus.nytStates = parsedStateData.map(numericalStats);
 			this.currentStatus.nytNationwide = parsedNationData.map(numericalStats);
+			// Adding this log to as to see the updated data in the interval
+			logger.info(`NYT county cache length: ${this.currentStatus.nytCounties.length}`);
+			logger.info(`NYT state cache length: ${this.currentStatus.nytStates.length}`);
 			logger.info('NYT local cache updated');
 		}
 	} catch (err) {

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -14,7 +14,6 @@ exports.currentStatus = {
 const calculatePriorDate = (lastDays) => {
 	var priorDate = new Date();
 	priorDate.setDate(priorDate.getDate() - lastDays);
-	// priorDate = priorDate.toISOString().slice(0, 10);
 	return priorDate.toISOString().slice(0, 10);
 };
 
@@ -28,8 +27,8 @@ exports.nytCounties = (lastdays = 30) => {
 	if (lastdays === 'all') {
 		return this.currentStatus.nytCounties;
 	} else {
-		const prior = calculatePriorDate(lastdays);
-		return this.currentStatus.nytCounties.filter((data) => data.date >= prior);
+		const priorDate = calculatePriorDate(lastdays);
+		return this.currentStatus.nytCounties.filter((data) => data.date >= priorDate);
 	}
 };
 
@@ -37,12 +36,11 @@ exports.nytStates = (lastdays = 30) => {
 	if (lastdays === 'all') {
 		return this.currentStatus.nytStates;
 	} else {
-		const prior = calculatePriorDate(lastdays);
-		return this.currentStatus.nytStates.filter((data) => data.date >= prior);
+		const priorDate = calculatePriorDate(lastdays);
+		return this.currentStatus.nytStates.filter((data) => data.date >= priorDate);
 	}
 };
 
-// exports.nytStates = () => this.currentStatus.nytStates;
 exports.nytNationwide = () => this.currentStatus.nytNationwide;
 exports.appleData = () => this.currentStatus.appleData;
 


### PR DESCRIPTION
- Multiple NYT endpoints have last days param

- Test cases enhanced to cater for the `lastdays=1` issue now checking for `lastdays=2` to be safe