### PR TITLE
getGovData-restructure

### DIFF
--- a/routes/v2/apiGov.js
+++ b/routes/v2/apiGov.js
@@ -8,16 +8,16 @@ const { redis, keys } = require('../instances');
 router.get('/v2/gov/:country?', async (req, res) => {
 	const { allowNull } = req.query;
 	const { country: countryName } = req.params;
-	const data = JSON.parse(await redis.get(keys.gov_countries));
 	if (countryName) {
 		const standardizedCountryName = nameUtils.getCountryData(countryName.trim()).country || countryName.trim();
-		if (data[standardizedCountryName]) {
-			res.send(!wordToBoolean(allowNull) ? nameUtils.transformNull(data[standardizedCountryName]) : data[standardizedCountryName]);
+		const data = JSON.parse(await redis.hget(keys.gov_countries, standardizedCountryName));
+		if (data) {
+			res.send(!wordToBoolean(allowNull) ? nameUtils.transformNull(data) : data);
 		} else {
 			res.status(404).send({ message: `Country '${standardizedCountryName}' not found or no data found for country` });
 		}
 	} else {
-		res.send(Object.keys(data));
+		res.send((await redis.hkeys(keys.gov_countries)).sort());
 	}
 });
 

--- a/scrapers/covid-19/govScrapers/getColombia.js
+++ b/scrapers/covid-19/govScrapers/getColombia.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const logger = require('../../../utils/logger');
 
+// THIS SCRAPER IS DEPRECATED - CODE NOT USED ANYWHERE
 const transformData = (data, cities) => {
 	const state = 13;
 	const gender = 15;

--- a/scrapers/covid-19/govScrapers/getGovData.js
+++ b/scrapers/covid-19/govScrapers/getGovData.js
@@ -11,6 +11,7 @@ const southAfricaData = require('./getSouthAfrica');
 const ukData = require('./getUK');
 const israelData = require('./getIsrael');
 const mexicoData = require('./getMexico');
+const nameUtils = require('../../../utils/nameUtils');
 
 const logger = require('../../../utils/logger');
 
@@ -21,16 +22,19 @@ const logger = require('../../../utils/logger');
  */
 const govData = async (keys, redis) => {
 	try {
-		const data = {};
-		const redisData = JSON.parse(await redis.get(keys.gov_countries));
+
 		const _resolveData = async (obj) => {
 			const { country, fn } = obj;
-			let countryData = await fn();
-			if (countryData === null) {
-				countryData = redisData[country] ? redisData[country] : null;
+			const countryData = await fn();
+
+			if (countryData) {
+				const standardizedCountryName = nameUtils.getCountryData(country.trim()).country;
+				await redis.hset(keys.gov_countries, standardizedCountryName, JSON.stringify(countryData));
+			} else {
+				logger.info(`${country} scraper has failed.`);
 			}
-			data[country] = countryData;
 		};
+
 		await Promise.all([
 			{ country: 'South Africa', fn: southAfricaData },
 			{ country: 'Canada', fn: canadaData },
@@ -41,13 +45,13 @@ const govData = async (keys, redis) => {
 			{ country: 'Nigeria', fn: nigeriaData },
 			{ country: 'India', fn: indiaData },
 			{ country: 'New Zealand', fn: newZealandData },
-			{ country: 'Colombia', fn: colombiaData },
+			// { country: 'Colombia', fn: colombiaData },
 			{ country: 'UK', fn: ukData },
 			{ country: 'Israel', fn: israelData },
 			{ country: 'Mexico', fn: mexicoData }
 		].map(_resolveData));
-		redis.set(keys.gov_countries, JSON.stringify(data));
-		logger.info(`Updated gov data: ${Object.keys(data).length} government sources`);
+
+		logger.info(`Updated gov data: ${(await redis.hkeys(keys.gov_countries)).length} government sources`);
 	} catch (err) {
 		logger.err('Error: Requesting Gov data failed!', err);
 	}

--- a/scrapers/covid-19/govScrapers/getGovData.js
+++ b/scrapers/covid-19/govScrapers/getGovData.js
@@ -6,7 +6,6 @@ const switzerlandData = require('./getSwitzerland');
 const nigeriaData = require('./getNigeria');
 const indiaData = require('./getIndia');
 const newZealandData = require('./getNewZealand');
-const colombiaData = require('./getColombia');
 const southAfricaData = require('./getSouthAfrica');
 const ukData = require('./getUK');
 const israelData = require('./getIsrael');
@@ -22,7 +21,6 @@ const logger = require('../../../utils/logger');
  */
 const govData = async (keys, redis) => {
 	try {
-
 		const _resolveData = async (obj) => {
 			const { country, fn } = obj;
 			const countryData = await fn();
@@ -45,7 +43,6 @@ const govData = async (keys, redis) => {
 			{ country: 'Nigeria', fn: nigeriaData },
 			{ country: 'India', fn: indiaData },
 			{ country: 'New Zealand', fn: newZealandData },
-			// { country: 'Colombia', fn: colombiaData },
 			{ country: 'UK', fn: ukData },
 			{ country: 'Israel', fn: israelData },
 			{ country: 'Mexico', fn: mexicoData }

--- a/scrapers/covid-19/govScrapers/getUK.js
+++ b/scrapers/covid-19/govScrapers/getUK.js
@@ -16,7 +16,7 @@ const ukData = async () => {
 			newAdmissions: 'newAdmissions',
 			admissions: 'cumAdmissions'
 		};
-		const response = (await axios.get(`https://api.coronavirus-staging.data.gov.uk/v1/data?filters=areaName=United%20Kingdom;areaType=overview&structure=${JSON.stringify(structure)}`)).data;
+		const response = (await axios.get(`https://api.coronavirus.data.gov.uk/v1/data?filters=areaName=United%20Kingdom;areaType=overview&structure=${JSON.stringify(structure)}`)).data;
 		for (const row of response.data.slice(0, response.length - 60)) {
 			data[row.date] = row;
 			delete data[row.date].date;

--- a/tests/v2/api_gov.spec.js
+++ b/tests/v2/api_gov.spec.js
@@ -372,20 +372,20 @@ describe('TESTING /v2/gov/new zealand', () => {
 	});
 });
 
-describe('TESTING /v2/gov/colombia', () => {
-	it('/v2/gov/colombia correct fields set', (done) => {
-		chai.request(app)
-			.get('/v2/gov/colombia')
-			.end((err, res) => {
-				testBasicProperties(err, res, 200, 'object');
-				res.body.should.have.property('updated');
-				res.body.should.have.property('departments');
-				res.body.should.have.property('cities');
-				res.body.departments.length.should.be.at.least(32);
-				done();
-			});
-	});
-});
+// describe('TESTING /v2/gov/colombia', () => {
+// 	it('/v2/gov/colombia correct fields set', (done) => {
+// 		chai.request(app)
+// 			.get('/v2/gov/colombia')
+// 			.end((err, res) => {
+// 				testBasicProperties(err, res, 200, 'object');
+// 				res.body.should.have.property('updated');
+// 				res.body.should.have.property('departments');
+// 				res.body.should.have.property('cities');
+// 				res.body.departments.length.should.be.at.least(32);
+// 				done();
+// 			});
+// 	});
+// });
 
 describe('TESTING /v2/gov/south africa', () => {
 	it('/v2/gov/south africa correct data', (done) => {

--- a/tests/v2/api_gov.spec.js
+++ b/tests/v2/api_gov.spec.js
@@ -28,7 +28,7 @@ describe('TESTING /v2/gov general', () => {
 			.get('/v2/gov')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				res.body.length.should.be(countries.length);
+				res.body.length.should.be.equal(countries.length);
 				res.body.forEach((country) => countries.should.include(country));
 				done();
 			});

--- a/tests/v2/api_gov.spec.js
+++ b/tests/v2/api_gov.spec.js
@@ -17,7 +17,6 @@ const countries = [
 	'Nigeria',
 	'India',
 	'New Zealand',
-	'Colombia',
 	'UK',
 	'Israel',
 	'Mexico'
@@ -29,7 +28,7 @@ describe('TESTING /v2/gov general', () => {
 			.get('/v2/gov')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				res.body.length.should.be.at.least(1);
+				res.body.length.should.be(countries.length);
 				res.body.forEach((country) => countries.should.include(country));
 				done();
 			});
@@ -371,21 +370,6 @@ describe('TESTING /v2/gov/new zealand', () => {
 			});
 	});
 });
-
-// describe('TESTING /v2/gov/colombia', () => {
-// 	it('/v2/gov/colombia correct fields set', (done) => {
-// 		chai.request(app)
-// 			.get('/v2/gov/colombia')
-// 			.end((err, res) => {
-// 				testBasicProperties(err, res, 200, 'object');
-// 				res.body.should.have.property('updated');
-// 				res.body.should.have.property('departments');
-// 				res.body.should.have.property('cities');
-// 				res.body.departments.length.should.be.at.least(32);
-// 				done();
-// 			});
-// 	});
-// });
 
 describe('TESTING /v2/gov/south africa', () => {
 	it('/v2/gov/south africa correct data', (done) => {

--- a/tests/v3/covid-19/api_gov.spec.js
+++ b/tests/v3/covid-19/api_gov.spec.js
@@ -28,7 +28,7 @@ describe('TESTING /v3/covid-19/gov general', () => {
 			.get('/v3/covid-19/gov')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				res.body.length.should.be(countries.length);
+				res.body.length.should.be.equal(countries.length);
 				res.body.forEach((country) => countries.should.include(country));
 				done();
 			});

--- a/tests/v3/covid-19/api_gov.spec.js
+++ b/tests/v3/covid-19/api_gov.spec.js
@@ -377,20 +377,20 @@ describe('TESTING /v3/covid-19/gov/new zealand', () => {
 	});
 });
 
-describe('TESTING /v3/covid-19/gov/colombia', () => {
-	it('/v3/covid-19/gov/colombia correct fields set', (done) => {
-		chai.request(app)
-			.get('/v3/covid-19/gov/colombia')
-			.end((err, res) => {
-				testBasicProperties(err, res, 200, 'object');
-				res.body.should.have.property('updated');
-				res.body.should.have.property('departments');
-				res.body.should.have.property('cities');
-				res.body.departments.length.should.be.at.least(32);
-				done();
-			});
-	});
-});
+// describe('TESTING /v3/covid-19/gov/colombia', () => {
+// 	it('/v3/covid-19/gov/colombia correct fields set', (done) => {
+// 		chai.request(app)
+// 			.get('/v3/covid-19/gov/colombia')
+// 			.end((err, res) => {
+// 				testBasicProperties(err, res, 200, 'object');
+// 				res.body.should.have.property('updated');
+// 				res.body.should.have.property('departments');
+// 				res.body.should.have.property('cities');
+// 				res.body.departments.length.should.be.at.least(32);
+// 				done();
+// 			});
+// 	});
+// });
 
 describe('TESTING /v3/covid-19/gov/south africa', () => {
 	it('/v3/covid-19/gov/south africa correct data', (done) => {

--- a/tests/v3/covid-19/api_gov.spec.js
+++ b/tests/v3/covid-19/api_gov.spec.js
@@ -16,7 +16,6 @@ const countries = [
 	'Nigeria',
 	'India',
 	'New Zealand',
-	'Colombia',
 	'South Africa',
 	'UK',
 	'Israel',
@@ -29,7 +28,7 @@ describe('TESTING /v3/covid-19/gov general', () => {
 			.get('/v3/covid-19/gov')
 			.end((err, res) => {
 				testBasicProperties(err, res, 200, 'array');
-				res.body.length.should.be.at.least(1);
+				res.body.length.should.be(countries.length);
 				res.body.forEach((country) => countries.should.include(country));
 				done();
 			});
@@ -376,21 +375,6 @@ describe('TESTING /v3/covid-19/gov/new zealand', () => {
 			});
 	});
 });
-
-// describe('TESTING /v3/covid-19/gov/colombia', () => {
-// 	it('/v3/covid-19/gov/colombia correct fields set', (done) => {
-// 		chai.request(app)
-// 			.get('/v3/covid-19/gov/colombia')
-// 			.end((err, res) => {
-// 				testBasicProperties(err, res, 200, 'object');
-// 				res.body.should.have.property('updated');
-// 				res.body.should.have.property('departments');
-// 				res.body.should.have.property('cities');
-// 				res.body.departments.length.should.be.at.least(32);
-// 				done();
-// 			});
-// 	});
-// });
 
 describe('TESTING /v3/covid-19/gov/south africa', () => {
 	it('/v3/covid-19/gov/south africa correct data', (done) => {


### PR DESCRIPTION
closes #875 
**Do not merge without Coleman on standby to delete the previous gov redis key. This restructure changes the key type and will cause errors**

steps to take in production:
1. inside redis-cli
```bash 
> DEL covidapi:gov_countries
```
2. restart the scraper service

---

- move each gov country's data into its own hash field to prevent broken scrapers from corrupting redis data for the others
- disable Colombia (requesting massive json payloads causing tests to timeout)
- fix the UK source URL again (still need to add a conditional to fallback to staging vs non-staging)

