### PR TITLE
Use Promise.race to get the first resolved response; ignore certificate errors

### DIFF
--- a/scrapers/covid-19/govScrapers/getUK.js
+++ b/scrapers/covid-19/govScrapers/getUK.js
@@ -1,9 +1,17 @@
 const axios = require('axios');
+const https = require('https');
 const logger = require('../../../utils/logger');
+
+const instance = axios.create({
+	httpsAgent: new https.Agent({
+		rejectUnauthorized: false
+	})
+});
 
 const ukData = async () => {
 	try {
-		var data = {};
+		const data = {};
+
 		const structure = {
 			date: 'date',
 			todayTests: 'newTestsByPublishDate',
@@ -16,12 +24,17 @@ const ukData = async () => {
 			newAdmissions: 'newAdmissions',
 			admissions: 'cumAdmissions'
 		};
-		const response = (await axios.get(`https://api.coronavirus.data.gov.uk/v1/data?filters=areaName=United%20Kingdom;areaType=overview&structure=${JSON.stringify(structure)}`)).data;
-		for (const row of response.data.slice(0, response.length - 60)) {
-			data[row.date] = row;
-			delete data[row.date].date;
-		}
-		return data;
+
+		const URL = (await instance.get(`https://api.coronavirus.data.gov.uk/v1/data?filters=areaName=United%20Kingdom;areaType=overview&structure=${JSON.stringify(structure)}`)).data;
+		const URL_STG = (await instance.get(`https://api.coronavirus-staging.data.gov.uk/v1/data?filters=areaName=United%20Kingdom;areaType=overview&structure=${JSON.stringify(structure)}`)).data;
+
+		return Promise.race([URL, URL_STG]).then(res => {
+			for (const row of res.data.slice(0, res.length - 60)) {
+				data[row.date] = row;
+				delete data[row.date].date;
+			}
+			return data;
+		});
 	} catch (err) {
 		logger.err('Error: Requesting UK Gov Data failed!', err);
 		return null;


### PR DESCRIPTION
This will address any future issues with the UK API breaking one of their endpoints.

1) ignore SSL certificate errors from this axios instance
2) use Promise.race to try both endpoints and take the first resolve

closes #857 