### PR TITLE
Run actions excluding paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,14 @@ name: Docker Publish
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '.github/**'
+      - 'docker-publish.yml'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'TERMS.md'
+      - 'privacy.md'
+      - 'CONTRIBUTING.md'
 jobs:
   publish:
     if: github.repository == 'disease-sh/API'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,25 @@ name: Eslint
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '.github/**'
+      - 'docker-publish.yml'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'TERMS.md'
+      - 'privacy.md'
+      - 'CONTRIBUTING.md'
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - '.github/**'
+      - 'docker-publish.yml'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'TERMS.md'
+      - 'privacy.md'
+      - 'CONTRIBUTING.md'
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,14 @@ name: Unittest
 on:
   push:
     branches: [master, v3-update]
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'docker-publish.yml'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'TERMS.md'
+      - 'privacy.md'
+      - 'CONTRIBUTING.md'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
We don't need to run actions on pushes to README type files, or the `.github` folder