### PR TITLE
Mexico traffic light

### DIFF
--- a/scrapers/covid-19/govScrapers/getMexico.js
+++ b/scrapers/covid-19/govScrapers/getMexico.js
@@ -50,32 +50,6 @@ const formData = {
 };
 
 /**
- * Filter items by the most recent date not older than 2 days
- * @param {Object} data	An object with a "date" property
- * @returns {Array}	Array filtered by date
- */
-const filterByDate = (data) => {
-	const date = new Date();
-	const decrementDate = () => date.setDate(date.getDate() - 1);
-	const filter = () => data.filter(item => item.date === `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`);
-	let filteredData = filter();
-
-	try {
-		let idx = 0;
-		while (!filteredData.length && idx < 2) {
-			idx++;
-			decrementDate();
-			filteredData = filter();
-		}
-		// return filteredData, or throw to force execution into the catch block
-		return filteredData.length ? filteredData : (() => { throw new Error('Unable to obtain data within date range'); })();
-	} catch (err) {
-		logger.err('filterByDate has failed', err);
-		return null;
-	}
-};
-
-/**
  * Gets the numerical value of an DOM node's innerHTML
  * @param {string} res A response body string
  * @param {string} 	identifier A unique class or ID whose innerHTML value to grab
@@ -88,7 +62,7 @@ const getInnerHTML = (res, identifier) => parseInt(res.substring(res.indexOf(ide
  * @param	{string} res	The response body string to extract data from
  * @returns {Object}	National data for Mexico
  */
-const getNationalToday = (res) => filterByDate(JSON.parse(res.substring(res.lastIndexOf('['), res.lastIndexOf(']') + 1)))[0];
+const getNationalToday = (res) => JSON.parse(res.substring(res.lastIndexOf('['), res.lastIndexOf(']') + 1)).pop();
 
 /**
  * Creates and returns an object containing data for each tracked Mexican state

--- a/tests/v2/api_gov.spec.js
+++ b/tests/v2/api_gov.spec.js
@@ -508,6 +508,7 @@ describe('TESTING /v2/gov/mexico', () => {
 				res.body.nationalData.todayDeaths.should.have.property('female');
 				res.body.nationalData.todayDeaths.should.have.property('total');
 				res.body.stateData[0].should.have.property('state');
+				res.body.stateData[0].should.have.property('color');
 				res.body.stateData[0].should.have.property('confirmed');
 				res.body.stateData[0].should.have.property('negative');
 				res.body.stateData[0].should.have.property('suspect');

--- a/tests/v3/covid-19/api_gov.spec.js
+++ b/tests/v3/covid-19/api_gov.spec.js
@@ -519,6 +519,7 @@ describe('TESTING /v3/covid-19/gov/mexico', () => {
 				res.body.nationalData.todayDeaths.should.have.property('female');
 				res.body.nationalData.todayDeaths.should.have.property('total');
 				res.body.stateData[0].should.have.property('state');
+				res.body.stateData[0].should.have.property('color');
 				res.body.stateData[0].should.have.property('confirmed');
 				res.body.stateData[0].should.have.property('negative');
 				res.body.stateData[0].should.have.property('suspect');


### PR DESCRIPTION
closes #877

1) adds the current "traffic light" ([info](https://coronavirus.gob.mx/semaforo/)) for each state
2) removes the strict filterByDate function to be more flexible with just a `.pop()`. This was related to bugs caused by Mexico data not being updated over the weekends.