### PR TITLE
Replace npm install with npm ci in order to respect package-lock.json

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install
+      - run: npm ci
       - run: npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:alpine
 # WORKDIR create the directory and then execute cd
 WORKDIR /home/container
 
-COPY ./package.json .
-RUN npm i
+COPY ./package.json ./package-lock.json ./
+RUN npm ci
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Disease.sh Documentation can be found [here](https://disease.sh/docs/)
 3. in the new `.env` file, change `REDIS_HOST` to localhost
 4. Change the env variables to fit your environment (leave them blank for default values)
 6. In one window run `redis-server`
-7. Run `npm install` to install the packages
+7. Run `npm ci` to install the packages
 8. In another window run `npm run start:dev`
 9. Open your browser and navigate to `localhost:{PORT}` (PORT being the port specified in your `.env` file)
 10. You should now see the APIs landing page


### PR DESCRIPTION
npm ci provides a more reliable way to create reproducible builds by
respectiving package-lock.json instead of installing the newest version
compatible with package.json

For more information see here: https://docs.npmjs.com/cli/ci.html