### PR TITLE
Add a comment to explain case 15 inside mapRows in Worldometer Scraper code file

### DIFF
--- a/scrapers/covid-19/getWorldometers.js
+++ b/scrapers/covid-19/getWorldometers.js
@@ -59,6 +59,12 @@ const mapRows = (_, row) => {
 				entry.countryInfo = countryInfo;
 				break;
 			}
+			/*
+				Index 15 refers to the following cell:
+				`<td style="display:none" data-continent="all"></td>`
+
+				Cheerio loads all columns of the table including those not selected inside the `Column` select element.
+			*/
 			case 15: {
 				entry[selector] = cell.text();
 				break;


### PR DESCRIPTION
While going through the code I got confused with the `case 15` inside the `mapRows()` function in the Worldometer Scraper file. 

When debugging the Worldometer page using the Dev Tools, I was always getting the number of cells per row was 15, hence index 15 was out of bound.

However, the Worldometer page has a `Columns` select element where in my case, I had `New Recovered` unselected. 

Seems `Cheerio` loads all cells even those unselected inside the `Columns` select element.