### PR TITLE
Feature request #978

### DIFF
--- a/public/apidocs/swagger_v3.json
+++ b/public/apidocs/swagger_v3.json
@@ -1237,7 +1237,7 @@
           "200": {
             "description": "Status Ok",
             "schema": {
-              "$ref": "#/definitions/vaccineStateCoverage"
+              "$ref": "#/definitions/vaccineStatesCoverage"
             }
           }
         }
@@ -2229,55 +2229,48 @@
        }
     },
     "vaccineCountriesCoverage":{
-       "type":"array",
-       "items":{
-         "type":"object",
-         "properties":{
-           "country":{
-             "type":"string"
-           },
-           "timeline":{
-             "type":"object",
-             "properties":{
-               "date":{
-                 "type":"number"
-               }
-             }
-           }
-         }
-       }
+      "type":"array",
+      "items":{
+        "$ref": "#/definitions/vaccineCountryCoverage"
+      }
     },
     "vaccineCountryCoverage":{
-       "type":"object",
-       "properties":{
-         "country":{
-           "type":"string"
-         },
-         "timeline":{
-           "type":"object",
-           "properties":{
-             "date":{
-               "type":"number"
-             }
-           }
-         }
-       }
+      "type":"object",
+      "properties":{
+        "country":{
+          "type":"string"
+        },
+        "timeline":{
+          "type":"object",
+          "properties":{
+            "date":{
+              "type":"number"
+            }
+          }
+        }
+      }
+    },
+    "vaccineStatesCoverage": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/vaccineStateCoverage"
+      }
     },
     "vaccineStateCoverage":{
-       "type":"object",
-       "properties":{
-         "state":{
-           "type":"string"
-         },
-         "timeline":{
-           "type":"object",
-           "properties":{
-             "date":{
-               "type":"number"
-             }
-           }
-         }
-       }
+      "type":"object",
+      "properties":{
+        "state":{
+          "type":"string"
+        },
+        "timeline":{
+          "type":"object",
+          "properties":{
+            "date":{
+              "type":"number"
+            }
+          }
+        }
+      }
     },
     "therapeutics": {
       "properties": {

--- a/routes/v3/covid-19/apiVaccine.js
+++ b/routes/v3/covid-19/apiVaccine.js
@@ -16,13 +16,9 @@ router.get('/v3/covid-19/vaccine/coverage', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.vaccine_coverage));
 	if (data) {
 		const { world } = data;
-		const { lastdays } = req.query;
-		const numericLastDays = getLastDays(lastdays);
-		const extractedData = {};
-		Object.keys(world).slice(numericLastDays * -1).forEach((date) => {
-			extractedData[date] = world[date].total;
-		});
-		res.send(extractedData);
+		const { lastDays, isFullData } = parseVaccineQueryParams(req.query);
+		const coverageData = buildVaccineTimeline(world, lastDays, isFullData);
+		res.send(coverageData);
 	} else {
 		res.status(404).send({ message: `Error fetching vaccine coverage data` });
 	}
@@ -32,14 +28,13 @@ router.get('/v3/covid-19/vaccine/coverage/countries', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.vaccine_coverage));
 	if (data) {
 		const { countries } = data;
-		const { lastdays } = req.query;
-		const numericLastDays = getLastDays(lastdays);
+		const { lastDays, isFullData } = parseVaccineQueryParams(req.query);
 		const extractedData = countries.map((country) => {
 			const { timeline } = country;
-			const obj = { country: country.country, timeline: {} };
-			Object.keys(timeline).slice(numericLastDays * -1).forEach((date) => {
-				obj.timeline[date] = timeline[date].total;
-			});
+			const obj = {
+				country: country.country,
+				timeline: buildVaccineTimeline(timeline, lastDays, isFullData)
+			};
 			return obj;
 		});
 		res.send(extractedData);
@@ -59,12 +54,11 @@ router.get('/v3/covid-19/vaccine/coverage/countries/:country', async (req, res) 
 			|| countryData.countryInfo.iso3.toLowerCase() === country.toLowerCase());
 		if (countryVaccineData) {
 			const { timeline } = countryVaccineData;
-			const { lastdays } = req.query;
-			const numericLastDays = getLastDays(lastdays);
-			const obj = { country: countryVaccineData.country, timeline: {} };
-			Object.keys(timeline).slice(numericLastDays * -1).forEach((date) => {
-				obj.timeline[date] = timeline[date].total;
-			});
+			const { lastDays, isFullData } = parseVaccineQueryParams(req.query);
+			const obj = {
+				country: countryVaccineData.country,
+				timeline: buildVaccineTimeline(timeline, lastDays, isFullData)
+			};
 			res.send(obj);
 		} else {
 			res.status(404).send({ message: 'No vaccine data for requested country or country does not exist' });
@@ -79,14 +73,13 @@ router.get('/v3/covid-19/vaccine/coverage/states', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.vaccine_state_coverage));
 	if (data) {
 		const { states } = data;
-		const { lastdays } = req.query;
-		const numericLastDays = getLastDays(lastdays);
+		const { lastDays, isFullData } = parseVaccineQueryParams(req.query);
 		const extractedData = states.map((state) => {
 			const { timeline } = state;
-			const obj = { state: state.state, timeline: {} };
-			Object.keys(timeline).slice(numericLastDays * -1).forEach((date) => {
-				obj.timeline[date] = timeline[date].total;
-			});
+			const obj = {
+				state: state.state,
+				timeline: buildVaccineTimeline(timeline, lastDays, isFullData)
+			};
 			return obj;
 		});
 		res.send(extractedData);
@@ -103,12 +96,11 @@ router.get('/v3/covid-19/vaccine/coverage/states/:query', async (req, res) => {
 		const stateVaccineData = states.find((stateData) => stateData.state.toLowerCase() === query.toLowerCase());
 		if (stateVaccineData) {
 			const { timeline } = stateVaccineData;
-			const { lastdays } = req.query;
-			const numericLastDays = getLastDays(lastdays);
-			const obj = { state: stateVaccineData.state, timeline: {} };
-			Object.keys(timeline).slice(numericLastDays * -1).forEach((date) => {
-				obj.timeline[date] = timeline[date].total;
-			});
+			const { lastDays, isFullData } = parseVaccineQueryParams(req.query);
+			const obj = {
+				state: stateVaccineData.state,
+				timeline: buildVaccineTimeline(timeline, lastDays, isFullData)
+			};
 			res.send(obj);
 		} else {
 			res.status(404).send({ message: 'No vaccine data for requested state or state does not exist' });
@@ -116,7 +108,70 @@ router.get('/v3/covid-19/vaccine/coverage/states/:query', async (req, res) => {
 	} else {
 		res.status(404).send({ message: 'Error fetching vaccine state coverage data' });
 	}
+});
+
+/**
+ * Reads the endpoint query parameters as strings and parses them into native js types.
+ * @param {*} requestQuery The express req.query object.
+ * @returns {*} Object contained the parsed query parameters.
+ */
+function parseVaccineQueryParams(requestQuery) {
+	const { lastdays, fullData } = requestQuery;
+	const numericLastDays = getLastDays(lastdays);
+	const parsedFullData = fullData === 'true';
+	return {
+		lastDays: numericLastDays,
+		isFullData: parsedFullData
+	};
 }
-);
+
+/**
+ * Builds and formats a vaccine timeline.
+ * @param {*} fullTimeline The full vaccine timeline data returned from redis.
+ * @param {number} numDays The number of previous days to include.
+ * @param {boolean} isFullData Whether or not to include the full vaccine data as a list, instead of an object keyed by date of only totals.
+ * @returns {*} Formatted vaccine timeline.
+ */
+function buildVaccineTimeline(fullTimeline, numDays, isFullData) {
+	const neededDates = Object.keys(fullTimeline).slice(numDays * -1);
+	return isFullData ? buildFullVaccineTimeline(neededDates, fullTimeline) : buildSimpleVaccineTimeline(neededDates, fullTimeline);
+}
+
+/**
+ * Builds a vaccine timeline of only totals for each date.
+ * @param {*} dates The list of dates we want to return data for.
+ * @param {*} timeline The original vaccine timeline returned from redis.
+ * @returns {*} Object keyed by date, where each value is the total for that date.
+ */
+function buildSimpleVaccineTimeline(dates, timeline) {
+	const simpleTimeline = {};
+	dates.forEach(date => {
+		simpleTimeline[date] = timeline[date].total;
+	});
+	return simpleTimeline;
+}
+
+/**
+ * Builds the vaccine timeline as a list of full data. The schema is:
+ * [
+ * 	 {
+ *     "total": number,
+ *     "daily": number,
+ *     "totalPerHundred": number,
+ *     "dailyPerMillion": number,
+ *     "date": string
+ *   }
+ * ]
+ * @param {*} dates The list of dates we want to return data for.
+ * @param {*} timeline The original vaccine timeline returned from redis.
+ * @returns {*} List of objects conforming to the above structure.
+ */
+function buildFullVaccineTimeline(dates, timeline) {
+	return dates.map(date => {
+		const dateData = timeline[date];
+		dateData.date = date;
+		return dateData;
+	});
+}
 
 module.exports = router;

--- a/tests/v3/covid-19/api_vaccine.spec.js
+++ b/tests/v3/covid-19/api_vaccine.spec.js
@@ -72,6 +72,16 @@ describe('Testing /v3/covid-19/vaccine/ vaccine coverage', () => {
 			});
 	});
 
+	it('/v3/covid-19/vaccine/coverage should return a list of full data objects', (done) => {
+		chai.request(app)
+			.get('/v3/covid-19/vaccine/coverage?fullData=true')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'array');
+				res.body.length.should.equal(30);
+				assertFullDataTimelineStructure(res.body);
+				done();
+			});
+	});
 
 	it('/v3/covid-19/vaccine/coverage/countries should return countries vaccine coverage data', (done) => {
 		chai.request(app)
@@ -106,6 +116,21 @@ describe('Testing /v3/covid-19/vaccine/ vaccine coverage', () => {
 				res.body[0].should.have.property('country');
 				res.body[0].should.have.property('timeline');
 				Object.keys(res.body[0].timeline).length.should.not.equal(0);
+				done();
+			});
+	});
+
+	it('/v3/covid-19/vaccine/coverage/countries should return full data for each country', (done) => {
+		chai.request(app)
+			.get('/v3/covid-19/vaccine/coverage/countries?fullData=true')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'array');
+				res.body.length.should.not.equal(0);
+				res.body[0].should.have.property('country');
+				res.body[0].should.have.property('timeline');
+				res.body[0].timeline.should.be.a('array');
+				res.body[0].timeline.length.should.equal(30);
+				assertFullDataTimelineStructure(res.body[0].timeline);
 				done();
 			});
 	});
@@ -192,3 +217,11 @@ describe('Testing /v3/covid-19/vaccine/ vaccine coverage', () => {
 		});
 	});
 });
+
+function assertFullDataTimelineStructure(fullDataTimeline) {
+	fullDataTimeline[0].should.have.property('total');
+	fullDataTimeline[0].should.have.property('daily');
+	fullDataTimeline[0].should.have.property('totalPerHundred');
+	fullDataTimeline[0].should.have.property('dailyPerMillion');
+	fullDataTimeline[0].should.have.property('date');
+}


### PR DESCRIPTION
Addresses #978

- Updates the following endpoints to accept a new query parameter `fullData`, which is a boolean indicating whether to return the full vaccine data as a list of objects while remaining backwards-compatible:
  - `/v3/covid-19/vaccine/coverage`
  - `/v3/covid-19/vaccine/coverage/countries`
  - `/v3/covid-19/vaccine/coverage/countries/:country`
  - `/v3/covid-19/vaccine/coverage/states`
  - `/v3/covid-19/vaccine/coverage/states/:query`
- Updates tests and swagger definitions.